### PR TITLE
feat: PNR protection service (AES-256-GCM)

### DIFF
--- a/CertifiedSkill/Services/Pnr/AesPnrProtectionService.cs
+++ b/CertifiedSkill/Services/Pnr/AesPnrProtectionService.cs
@@ -1,0 +1,101 @@
+using System.Security.Cryptography;
+using System.Text;
+using CertifiedSkill.Data.Protection;
+using Microsoft.Extensions.Options;
+
+namespace CertifiedSkill.Services.Pnr
+{
+    /// <summary>
+    /// AES-256-GCM implementation of IPnrProtectionService.
+    /// Uses versioned keys from PnrProtectionOptions.
+    /// </summary>
+    public sealed class AesPnrProtectionService : IPnrProtectionService
+    {
+        private const int NonceSizeBytes = 12;
+        private const int TagSizeBytes = 16;
+        private readonly PnrProtectionOptions _options;
+
+        public AesPnrProtectionService(IOptions<PnrProtectionOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        public (string EncryptedValue, string KeyVersion) Encrypt(string normalizedPnr)
+        {
+            EnsureEnabled();
+
+            var keyVersion = _options.ActiveEncryptionKeyVersion;
+            var keyBytes = GetEncryptionKey(keyVersion);
+
+            var plaintext = Encoding.UTF8.GetBytes(normalizedPnr);
+            var nonce = RandomNumberGenerator.GetBytes(NonceSizeBytes);
+            var ciphertext = new byte[plaintext.Length];
+            var tag = new byte[TagSizeBytes];
+
+            using var aesGcm = new AesGcm(keyBytes, TagSizeBytes);
+            aesGcm.Encrypt(nonce, plaintext, ciphertext, tag);
+
+            // Format: base64(nonce + ciphertext + tag)
+            var combined = new byte[NonceSizeBytes + ciphertext.Length + TagSizeBytes];
+            nonce.CopyTo(combined, 0);
+            ciphertext.CopyTo(combined, NonceSizeBytes);
+            tag.CopyTo(combined, NonceSizeBytes + ciphertext.Length);
+
+            return (Convert.ToBase64String(combined), keyVersion);
+        }
+
+        public string Decrypt(string encryptedValue, string keyVersion)
+        {
+            EnsureEnabled();
+
+            var keyBytes = GetEncryptionKey(keyVersion);
+            var combined = Convert.FromBase64String(encryptedValue);
+
+            if (combined.Length < NonceSizeBytes + TagSizeBytes)
+                throw new CryptographicException("Invalid encrypted value: too short.");
+
+            var nonce = combined[..NonceSizeBytes];
+            var tag = combined[^TagSizeBytes..];
+            var ciphertext = combined[NonceSizeBytes..^TagSizeBytes];
+            var plaintext = new byte[ciphertext.Length];
+
+            using var aesGcm = new AesGcm(keyBytes, TagSizeBytes);
+            aesGcm.Decrypt(nonce, ciphertext, tag, plaintext);
+
+            return Encoding.UTF8.GetString(plaintext);
+        }
+
+        public string ComputeHash(string normalizedPnr)
+        {
+            EnsureEnabled();
+
+            var keyVersion = _options.ActiveHashKeyVersion;
+            var keyBytes = GetHashKey(keyVersion);
+            var data = Encoding.UTF8.GetBytes(normalizedPnr);
+
+            using var hmac = new HMACSHA256(keyBytes);
+            var hash = hmac.ComputeHash(data);
+            return Convert.ToBase64String(hash);
+        }
+
+        private void EnsureEnabled()
+        {
+            if (!_options.Enabled)
+                throw new InvalidOperationException("PNR protection is not enabled.");
+        }
+
+        private byte[] GetEncryptionKey(string version)
+        {
+            if (!_options.EncryptionKeys.TryGetValue(version, out var base64Key))
+                throw new InvalidOperationException($"Encryption key version '{version}' is not configured.");
+            return Convert.FromBase64String(base64Key);
+        }
+
+        private byte[] GetHashKey(string version)
+        {
+            if (!_options.HashKeys.TryGetValue(version, out var base64Key))
+                throw new InvalidOperationException($"Hash key version '{version}' is not configured.");
+            return Convert.FromBase64String(base64Key);
+        }
+    }
+}

--- a/CertifiedSkill/Services/Pnr/IPnrProtectionService.cs
+++ b/CertifiedSkill/Services/Pnr/IPnrProtectionService.cs
@@ -1,0 +1,24 @@
+namespace CertifiedSkill.Services.Pnr
+{
+    /// <summary>
+    /// Handles encryption, decryption and hashing of Swedish personal identity numbers (PNR).
+    /// All operations require PNR to be normalized before calling.
+    /// </summary>
+    public interface IPnrProtectionService
+    {
+        /// <summary>
+        /// Encrypts a normalized PNR. Returns the encrypted value and the key version used.
+        /// </summary>
+        (string EncryptedValue, string KeyVersion) Encrypt(string normalizedPnr);
+
+        /// <summary>
+        /// Decrypts an encrypted PNR using the specified key version.
+        /// </summary>
+        string Decrypt(string encryptedValue, string keyVersion);
+
+        /// <summary>
+        /// Computes a stable HMAC-SHA256 hash of a normalized PNR for deduplication and lookup.
+        /// </summary>
+        string ComputeHash(string normalizedPnr);
+    }
+}

--- a/CertifiedSkill/Tests/CertifiedSkill.Tests/AesPnrProtectionServiceTests.cs
+++ b/CertifiedSkill/Tests/CertifiedSkill.Tests/AesPnrProtectionServiceTests.cs
@@ -1,0 +1,142 @@
+using CertifiedSkill.Data.Protection;
+using CertifiedSkill.Services.Pnr;
+using Microsoft.Extensions.Options;
+
+namespace CertifiedSkill.Tests
+{
+    public class AesPnrProtectionServiceTests
+    {
+        private static AesPnrProtectionService CreateService(bool enabled = true)
+        {
+            var keyMaterial = Convert.ToBase64String(new byte[32]);
+
+            var options = new PnrProtectionOptions
+            {
+                Enabled = enabled,
+                ActiveEncryptionKeyVersion = "2026-04",
+                ActiveHashKeyVersion = "2026-04",
+                EncryptionKeysConfiguration = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["2026-04"] = keyMaterial
+                },
+                HashKeysConfiguration = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["2026-04"] = keyMaterial
+                }
+            };
+
+            return new AesPnrProtectionService(Options.Create(options));
+        }
+
+        [Fact]
+        public void Encrypt_ShouldReturnEncryptedValue_AndActiveKeyVersion()
+        {
+            var service = CreateService();
+
+            var (encryptedValue, keyVersion) = service.Encrypt("199001011234");
+
+            Assert.False(string.IsNullOrEmpty(encryptedValue));
+            Assert.Equal("2026-04", keyVersion);
+        }
+
+        [Fact]
+        public void Encrypt_ShouldNotContainPlaintextPnr()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var (encryptedValue, _) = service.Encrypt(pnr);
+
+            Assert.DoesNotContain(pnr, encryptedValue);
+        }
+
+        [Fact]
+        public void Encrypt_ShouldProduceDifferentCiphertexts_ForSamePnr()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var (first, _) = service.Encrypt(pnr);
+            var (second, _) = service.Encrypt(pnr);
+
+            // AES-GCM uses random nonce so same plaintext gives different ciphertext
+            Assert.NotEqual(first, second);
+        }
+
+        [Fact]
+        public void Decrypt_ShouldReturnOriginalPnr_AfterEncrypt()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var (encryptedValue, keyVersion) = service.Encrypt(pnr);
+            var decrypted = service.Decrypt(encryptedValue, keyVersion);
+
+            Assert.Equal(pnr, decrypted);
+        }
+
+        [Fact]
+        public void Decrypt_ShouldThrow_WhenEncryptedValueIsTampered()
+        {
+            var service = CreateService();
+            var (encryptedValue, keyVersion) = service.Encrypt("199001011234");
+
+            // Tamper with the ciphertext
+            var bytes = Convert.FromBase64String(encryptedValue);
+            bytes[15] ^= 0xFF;
+            var tampered = Convert.ToBase64String(bytes);
+
+            Assert.ThrowsAny<Exception>(() => service.Decrypt(tampered, keyVersion));
+        }
+
+        [Fact]
+        public void ComputeHash_ShouldReturnSameHash_ForSamePnr()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var first = service.ComputeHash(pnr);
+            var second = service.ComputeHash(pnr);
+
+            Assert.Equal(first, second);
+        }
+
+        [Fact]
+        public void ComputeHash_ShouldReturnDifferentHash_ForDifferentPnr()
+        {
+            var service = CreateService();
+
+            var hash1 = service.ComputeHash("199001011234");
+            var hash2 = service.ComputeHash("198505052345");
+
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void ComputeHash_ShouldNotContainPlaintextPnr()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var hash = service.ComputeHash(pnr);
+
+            Assert.DoesNotContain(pnr, hash);
+        }
+
+        [Fact]
+        public void Encrypt_ShouldThrow_WhenProtectionIsDisabled()
+        {
+            var service = CreateService(enabled: false);
+
+            Assert.Throws<InvalidOperationException>(() => service.Encrypt("199001011234"));
+        }
+
+        [Fact]
+        public void ComputeHash_ShouldThrow_WhenProtectionIsDisabled()
+        {
+            var service = CreateService(enabled: false);
+
+            Assert.Throws<InvalidOperationException>(() => service.ComputeHash("199001011234"));
+        }
+    }
+}


### PR DESCRIPTION
## Vad
Lägger till IPnrProtectionService och AES-256-GCM implementation för kryptering och hashning av personnummer.

## Varför
Krypteringstjänsten är grunden för all PNR-hantering i systemet.

## Tester
10 enhetstester – alla gröna.