### PR TITLE
feat: Person entity med krypterat PNR och EF migration

### DIFF
--- a/CertifiedSkill/Data/ApplicationDbContext.cs
+++ b/CertifiedSkill/Data/ApplicationDbContext.cs
@@ -21,6 +21,16 @@ namespace CertifiedSkill.Data
                 entity.HasIndex(e => e.Email).IsUnique();
                 entity.Property(e => e.DisplayName).HasMaxLength(256).IsRequired();
                 entity.Property(e => e.CreatedAt).IsRequired();
+
+                // PNR fields - nullable, never stored in plaintext
+                entity.Property(e => e.EncryptedPnr).HasMaxLength(512);
+                entity.Property(e => e.PnrKeyVersion).HasMaxLength(64);
+                entity.Property(e => e.PnrHash).HasMaxLength(88);
+
+                // PnrHash is unique when set - prevents duplicates
+                entity.HasIndex(e => e.PnrHash)
+                      .IsUnique()
+                      .HasFilter("[PnrHash] IS NOT NULL");
             });
 
             builder.Entity<Certificate>(entity =>
@@ -48,4 +58,3 @@ namespace CertifiedSkill.Data
         }
     }
 }
-

--- a/CertifiedSkill/Data/Migrations/20260504152228_AddPnrFieldsToPerson.Designer.cs
+++ b/CertifiedSkill/Data/Migrations/20260504152228_AddPnrFieldsToPerson.Designer.cs
@@ -4,16 +4,19 @@ using CertifiedSkill.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace CertifiedSkill.Migrations
+namespace CertifiedSkill.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504152228_AddPnrFieldsToPerson")]
+    partial class AddPnrFieldsToPerson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CertifiedSkill/Data/Migrations/20260504152228_AddPnrFieldsToPerson.cs
+++ b/CertifiedSkill/Data/Migrations/20260504152228_AddPnrFieldsToPerson.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CertifiedSkill.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPnrFieldsToPerson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EncryptedPnr",
+                table: "Persons",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PnrHash",
+                table: "Persons",
+                type: "nvarchar(88)",
+                maxLength: 88,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PnrKeyVersion",
+                table: "Persons",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Persons_PnrHash",
+                table: "Persons",
+                column: "PnrHash",
+                unique: true,
+                filter: "[PnrHash] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Persons_PnrHash",
+                table: "Persons");
+
+            migrationBuilder.DropColumn(
+                name: "EncryptedPnr",
+                table: "Persons");
+
+            migrationBuilder.DropColumn(
+                name: "PnrHash",
+                table: "Persons");
+
+            migrationBuilder.DropColumn(
+                name: "PnrKeyVersion",
+                table: "Persons");
+        }
+    }
+}

--- a/CertifiedSkill/Data/Participant/Person.cs
+++ b/CertifiedSkill/Data/Participant/Person.cs
@@ -13,6 +13,25 @@ namespace CertifiedSkill.Data.Participant
 
         public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
 
+        /// <summary>
+        /// AES-256-GCM encrypted PNR. Never exposed in logs or UI.
+        /// Null if PNR has not been provided.
+        /// </summary>
+        public string? EncryptedPnr { get; set; }
+
+        /// <summary>
+        /// The key version used to encrypt EncryptedPnr.
+        /// Required when EncryptedPnr is set.
+        /// </summary>
+        public string? PnrKeyVersion { get; set; }
+
+        /// <summary>
+        /// HMAC-SHA256 hash of the normalized PNR.
+        /// Used for deduplication and lookup without exposing plaintext.
+        /// Null if PNR has not been provided.
+        /// </summary>
+        public string? PnrHash { get; set; }
+
         public ICollection<Certificate> Certificates { get; init; } = new List<Certificate>();
     }
 }


### PR DESCRIPTION
## Vad
Lägger till EncryptedPnr, PnrKeyVersion och PnrHash till Person-entiteten med EF Core migration.

## Varför
Person-entiteten är system of record för PNR-data. Fälten möjliggör säker lagring och sökning utan klartext.

## Tester
47 tester – alla gröna.

Closes #10