### PR TITLE
feat: Hashad PNR-sökning och dedupe i ParticipantPersonService

### DIFF
--- a/CertifiedSkill/Data/ApplicationDbContext.cs
+++ b/CertifiedSkill/Data/ApplicationDbContext.cs
@@ -21,6 +21,16 @@ namespace CertifiedSkill.Data
                 entity.HasIndex(e => e.Email).IsUnique();
                 entity.Property(e => e.DisplayName).HasMaxLength(256).IsRequired();
                 entity.Property(e => e.CreatedAt).IsRequired();
+
+                // PNR fields - nullable, never stored in plaintext
+                entity.Property(e => e.EncryptedPnr).HasMaxLength(512);
+                entity.Property(e => e.PnrKeyVersion).HasMaxLength(64);
+                entity.Property(e => e.PnrHash).HasMaxLength(88);
+
+                // PnrHash is unique when set - prevents duplicates
+                entity.HasIndex(e => e.PnrHash)
+                      .IsUnique()
+                      .HasFilter("[PnrHash] IS NOT NULL");
             });
 
             builder.Entity<Certificate>(entity =>
@@ -48,4 +58,3 @@ namespace CertifiedSkill.Data
         }
     }
 }
-

--- a/CertifiedSkill/Data/Migrations/20260504152228_AddPnrFieldsToPerson.Designer.cs
+++ b/CertifiedSkill/Data/Migrations/20260504152228_AddPnrFieldsToPerson.Designer.cs
@@ -4,16 +4,19 @@ using CertifiedSkill.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace CertifiedSkill.Migrations
+namespace CertifiedSkill.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504152228_AddPnrFieldsToPerson")]
+    partial class AddPnrFieldsToPerson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CertifiedSkill/Data/Migrations/20260504152228_AddPnrFieldsToPerson.cs
+++ b/CertifiedSkill/Data/Migrations/20260504152228_AddPnrFieldsToPerson.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CertifiedSkill.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPnrFieldsToPerson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EncryptedPnr",
+                table: "Persons",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PnrHash",
+                table: "Persons",
+                type: "nvarchar(88)",
+                maxLength: 88,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PnrKeyVersion",
+                table: "Persons",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Persons_PnrHash",
+                table: "Persons",
+                column: "PnrHash",
+                unique: true,
+                filter: "[PnrHash] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Persons_PnrHash",
+                table: "Persons");
+
+            migrationBuilder.DropColumn(
+                name: "EncryptedPnr",
+                table: "Persons");
+
+            migrationBuilder.DropColumn(
+                name: "PnrHash",
+                table: "Persons");
+
+            migrationBuilder.DropColumn(
+                name: "PnrKeyVersion",
+                table: "Persons");
+        }
+    }
+}

--- a/CertifiedSkill/Data/Participant/Person.cs
+++ b/CertifiedSkill/Data/Participant/Person.cs
@@ -13,6 +13,25 @@ namespace CertifiedSkill.Data.Participant
 
         public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
 
+        /// <summary>
+        /// AES-256-GCM encrypted PNR. Never exposed in logs or UI.
+        /// Null if PNR has not been provided.
+        /// </summary>
+        public string? EncryptedPnr { get; set; }
+
+        /// <summary>
+        /// The key version used to encrypt EncryptedPnr.
+        /// Required when EncryptedPnr is set.
+        /// </summary>
+        public string? PnrKeyVersion { get; set; }
+
+        /// <summary>
+        /// HMAC-SHA256 hash of the normalized PNR.
+        /// Used for deduplication and lookup without exposing plaintext.
+        /// Null if PNR has not been provided.
+        /// </summary>
+        public string? PnrHash { get; set; }
+
         public ICollection<Certificate> Certificates { get; init; } = new List<Certificate>();
     }
 }

--- a/CertifiedSkill/Services/Participant/ParticipantPersonService.cs
+++ b/CertifiedSkill/Services/Participant/ParticipantPersonService.cs
@@ -1,18 +1,93 @@
 using CertifiedSkill.Data;
+using CertifiedSkill.Data.Identity;
 using CertifiedSkill.Data.Participant;
+using CertifiedSkill.Services.Pnr;
 using Microsoft.EntityFrameworkCore;
 
 namespace CertifiedSkill.Services.Participant
 {
-    public sealed class ParticipantPersonService(ApplicationDbContext db)
+    public sealed class ParticipantPersonService(
+        ApplicationDbContext db,
+        IPnrProtectionService pnrProtection,
+        IPersonalIdentityNumberValidator pnrValidator)
     {
         /// <summary>
-        /// Returns the <see cref="Person"/> for the given normalised email,
+        /// Returns the Person for the given normalised email,
         /// or null if no person is linked to that email yet.
         /// </summary>
         public Task<Person?> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default) =>
             db.Persons
               .Include(p => p.Certificates)
               .FirstOrDefaultAsync(p => p.Email == normalizedEmail, cancellationToken);
+
+        /// <summary>
+        /// Finds a Person by PNR hash for deduplication and lookup.
+        /// Never accepts plaintext PNR - validates and hashes before lookup.
+        /// Returns null if no person with that PNR exists.
+        /// </summary>
+        public async Task<Person?> FindByPnrAsync(string rawPnr, CancellationToken cancellationToken = default)
+        {
+            if (!pnrValidator.TryNormalize(rawPnr, out var normalizedPnr))
+                throw new ArgumentException("Invalid PNR format.", nameof(rawPnr));
+
+            var pnrHash = pnrProtection.ComputeHash(normalizedPnr);
+
+            return await db.Persons
+                .Include(p => p.Certificates)
+                .FirstOrDefaultAsync(p => p.PnrHash == pnrHash, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns true if a Person with the given PNR already exists.
+        /// Used for deduplication before creating a new Person.
+        /// </summary>
+        public async Task<bool> ExistsByPnrAsync(string rawPnr, CancellationToken cancellationToken = default)
+        {
+            if (!pnrValidator.TryNormalize(rawPnr, out var normalizedPnr))
+                throw new ArgumentException("Invalid PNR format.", nameof(rawPnr));
+
+            var pnrHash = pnrProtection.ComputeHash(normalizedPnr);
+
+            return await db.Persons
+                .AnyAsync(p => p.PnrHash == pnrHash, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new Person with encrypted PNR and PNR hash.
+        /// Validates PNR format and checks for duplicates before saving.
+        /// </summary>
+        public async Task<Person> CreateWithPnrAsync(
+            string email,
+            string displayName,
+            string rawPnr,
+            CancellationToken cancellationToken = default)
+        {
+            if (!pnrValidator.TryNormalize(rawPnr, out var normalizedPnr))
+                throw new ArgumentException("Invalid PNR format.", nameof(rawPnr));
+
+            var pnrHash = pnrProtection.ComputeHash(normalizedPnr);
+
+            var exists = await db.Persons
+                .AnyAsync(p => p.PnrHash == pnrHash, cancellationToken);
+
+            if (exists)
+                throw new InvalidOperationException("A person with this PNR already exists.");
+
+            var (encryptedPnr, keyVersion) = pnrProtection.Encrypt(normalizedPnr);
+
+            var person = new Person
+            {
+                Email = email.Trim().ToLowerInvariant(),
+                DisplayName = displayName,
+                EncryptedPnr = encryptedPnr,
+                PnrKeyVersion = keyVersion,
+                PnrHash = pnrHash
+            };
+
+            db.Persons.Add(person);
+            await db.SaveChangesAsync(cancellationToken);
+
+            return person;
+        }
     }
 }

--- a/CertifiedSkill/Services/Pnr/AesPnrProtectionService.cs
+++ b/CertifiedSkill/Services/Pnr/AesPnrProtectionService.cs
@@ -1,0 +1,101 @@
+using System.Security.Cryptography;
+using System.Text;
+using CertifiedSkill.Data.Protection;
+using Microsoft.Extensions.Options;
+
+namespace CertifiedSkill.Services.Pnr
+{
+    /// <summary>
+    /// AES-256-GCM implementation of IPnrProtectionService.
+    /// Uses versioned keys from PnrProtectionOptions.
+    /// </summary>
+    public sealed class AesPnrProtectionService : IPnrProtectionService
+    {
+        private const int NonceSizeBytes = 12;
+        private const int TagSizeBytes = 16;
+        private readonly PnrProtectionOptions _options;
+
+        public AesPnrProtectionService(IOptions<PnrProtectionOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        public (string EncryptedValue, string KeyVersion) Encrypt(string normalizedPnr)
+        {
+            EnsureEnabled();
+
+            var keyVersion = _options.ActiveEncryptionKeyVersion;
+            var keyBytes = GetEncryptionKey(keyVersion);
+
+            var plaintext = Encoding.UTF8.GetBytes(normalizedPnr);
+            var nonce = RandomNumberGenerator.GetBytes(NonceSizeBytes);
+            var ciphertext = new byte[plaintext.Length];
+            var tag = new byte[TagSizeBytes];
+
+            using var aesGcm = new AesGcm(keyBytes, TagSizeBytes);
+            aesGcm.Encrypt(nonce, plaintext, ciphertext, tag);
+
+            // Format: base64(nonce + ciphertext + tag)
+            var combined = new byte[NonceSizeBytes + ciphertext.Length + TagSizeBytes];
+            nonce.CopyTo(combined, 0);
+            ciphertext.CopyTo(combined, NonceSizeBytes);
+            tag.CopyTo(combined, NonceSizeBytes + ciphertext.Length);
+
+            return (Convert.ToBase64String(combined), keyVersion);
+        }
+
+        public string Decrypt(string encryptedValue, string keyVersion)
+        {
+            EnsureEnabled();
+
+            var keyBytes = GetEncryptionKey(keyVersion);
+            var combined = Convert.FromBase64String(encryptedValue);
+
+            if (combined.Length < NonceSizeBytes + TagSizeBytes)
+                throw new CryptographicException("Invalid encrypted value: too short.");
+
+            var nonce = combined[..NonceSizeBytes];
+            var tag = combined[^TagSizeBytes..];
+            var ciphertext = combined[NonceSizeBytes..^TagSizeBytes];
+            var plaintext = new byte[ciphertext.Length];
+
+            using var aesGcm = new AesGcm(keyBytes, TagSizeBytes);
+            aesGcm.Decrypt(nonce, ciphertext, tag, plaintext);
+
+            return Encoding.UTF8.GetString(plaintext);
+        }
+
+        public string ComputeHash(string normalizedPnr)
+        {
+            EnsureEnabled();
+
+            var keyVersion = _options.ActiveHashKeyVersion;
+            var keyBytes = GetHashKey(keyVersion);
+            var data = Encoding.UTF8.GetBytes(normalizedPnr);
+
+            using var hmac = new HMACSHA256(keyBytes);
+            var hash = hmac.ComputeHash(data);
+            return Convert.ToBase64String(hash);
+        }
+
+        private void EnsureEnabled()
+        {
+            if (!_options.Enabled)
+                throw new InvalidOperationException("PNR protection is not enabled.");
+        }
+
+        private byte[] GetEncryptionKey(string version)
+        {
+            if (!_options.EncryptionKeys.TryGetValue(version, out var base64Key))
+                throw new InvalidOperationException($"Encryption key version '{version}' is not configured.");
+            return Convert.FromBase64String(base64Key);
+        }
+
+        private byte[] GetHashKey(string version)
+        {
+            if (!_options.HashKeys.TryGetValue(version, out var base64Key))
+                throw new InvalidOperationException($"Hash key version '{version}' is not configured.");
+            return Convert.FromBase64String(base64Key);
+        }
+    }
+}

--- a/CertifiedSkill/Services/Pnr/IPnrProtectionService.cs
+++ b/CertifiedSkill/Services/Pnr/IPnrProtectionService.cs
@@ -1,0 +1,24 @@
+namespace CertifiedSkill.Services.Pnr
+{
+    /// <summary>
+    /// Handles encryption, decryption and hashing of Swedish personal identity numbers (PNR).
+    /// All operations require PNR to be normalized before calling.
+    /// </summary>
+    public interface IPnrProtectionService
+    {
+        /// <summary>
+        /// Encrypts a normalized PNR. Returns the encrypted value and the key version used.
+        /// </summary>
+        (string EncryptedValue, string KeyVersion) Encrypt(string normalizedPnr);
+
+        /// <summary>
+        /// Decrypts an encrypted PNR using the specified key version.
+        /// </summary>
+        string Decrypt(string encryptedValue, string keyVersion);
+
+        /// <summary>
+        /// Computes a stable HMAC-SHA256 hash of a normalized PNR for deduplication and lookup.
+        /// </summary>
+        string ComputeHash(string normalizedPnr);
+    }
+}

--- a/CertifiedSkill/Tests/CertifiedSkill.Tests/AesPnrProtectionServiceTests.cs
+++ b/CertifiedSkill/Tests/CertifiedSkill.Tests/AesPnrProtectionServiceTests.cs
@@ -1,0 +1,142 @@
+using CertifiedSkill.Data.Protection;
+using CertifiedSkill.Services.Pnr;
+using Microsoft.Extensions.Options;
+
+namespace CertifiedSkill.Tests
+{
+    public class AesPnrProtectionServiceTests
+    {
+        private static AesPnrProtectionService CreateService(bool enabled = true)
+        {
+            var keyMaterial = Convert.ToBase64String(new byte[32]);
+
+            var options = new PnrProtectionOptions
+            {
+                Enabled = enabled,
+                ActiveEncryptionKeyVersion = "2026-04",
+                ActiveHashKeyVersion = "2026-04",
+                EncryptionKeysConfiguration = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["2026-04"] = keyMaterial
+                },
+                HashKeysConfiguration = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["2026-04"] = keyMaterial
+                }
+            };
+
+            return new AesPnrProtectionService(Options.Create(options));
+        }
+
+        [Fact]
+        public void Encrypt_ShouldReturnEncryptedValue_AndActiveKeyVersion()
+        {
+            var service = CreateService();
+
+            var (encryptedValue, keyVersion) = service.Encrypt("199001011234");
+
+            Assert.False(string.IsNullOrEmpty(encryptedValue));
+            Assert.Equal("2026-04", keyVersion);
+        }
+
+        [Fact]
+        public void Encrypt_ShouldNotContainPlaintextPnr()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var (encryptedValue, _) = service.Encrypt(pnr);
+
+            Assert.DoesNotContain(pnr, encryptedValue);
+        }
+
+        [Fact]
+        public void Encrypt_ShouldProduceDifferentCiphertexts_ForSamePnr()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var (first, _) = service.Encrypt(pnr);
+            var (second, _) = service.Encrypt(pnr);
+
+            // AES-GCM uses random nonce so same plaintext gives different ciphertext
+            Assert.NotEqual(first, second);
+        }
+
+        [Fact]
+        public void Decrypt_ShouldReturnOriginalPnr_AfterEncrypt()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var (encryptedValue, keyVersion) = service.Encrypt(pnr);
+            var decrypted = service.Decrypt(encryptedValue, keyVersion);
+
+            Assert.Equal(pnr, decrypted);
+        }
+
+        [Fact]
+        public void Decrypt_ShouldThrow_WhenEncryptedValueIsTampered()
+        {
+            var service = CreateService();
+            var (encryptedValue, keyVersion) = service.Encrypt("199001011234");
+
+            // Tamper with the ciphertext
+            var bytes = Convert.FromBase64String(encryptedValue);
+            bytes[15] ^= 0xFF;
+            var tampered = Convert.ToBase64String(bytes);
+
+            Assert.ThrowsAny<Exception>(() => service.Decrypt(tampered, keyVersion));
+        }
+
+        [Fact]
+        public void ComputeHash_ShouldReturnSameHash_ForSamePnr()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var first = service.ComputeHash(pnr);
+            var second = service.ComputeHash(pnr);
+
+            Assert.Equal(first, second);
+        }
+
+        [Fact]
+        public void ComputeHash_ShouldReturnDifferentHash_ForDifferentPnr()
+        {
+            var service = CreateService();
+
+            var hash1 = service.ComputeHash("199001011234");
+            var hash2 = service.ComputeHash("198505052345");
+
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void ComputeHash_ShouldNotContainPlaintextPnr()
+        {
+            var service = CreateService();
+            var pnr = "199001011234";
+
+            var hash = service.ComputeHash(pnr);
+
+            Assert.DoesNotContain(pnr, hash);
+        }
+
+        [Fact]
+        public void Encrypt_ShouldThrow_WhenProtectionIsDisabled()
+        {
+            var service = CreateService(enabled: false);
+
+            Assert.Throws<InvalidOperationException>(() => service.Encrypt("199001011234"));
+        }
+
+        [Fact]
+        public void ComputeHash_ShouldThrow_WhenProtectionIsDisabled()
+        {
+            var service = CreateService(enabled: false);
+
+            Assert.Throws<InvalidOperationException>(() => service.ComputeHash("199001011234"));
+        }
+    }
+}

--- a/CertifiedSkill/Tests/CertifiedSkill.Tests/ParticipantPersonServiceTests.cs
+++ b/CertifiedSkill/Tests/CertifiedSkill.Tests/ParticipantPersonServiceTests.cs
@@ -1,0 +1,155 @@
+using CertifiedSkill.Data;
+using CertifiedSkill.Data.Identity;
+using CertifiedSkill.Data.Participant;
+using CertifiedSkill.Data.Protection;
+using CertifiedSkill.Services.Participant;
+using CertifiedSkill.Services.Pnr;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace CertifiedSkill.Tests
+{
+    public class ParticipantPersonServiceTests
+    {
+        private static AesPnrProtectionService CreatePnrService()
+        {
+            var keyMaterial = Convert.ToBase64String(new byte[32]);
+            var options = new PnrProtectionOptions
+            {
+                Enabled = true,
+                ActiveEncryptionKeyVersion = "2026-04",
+                ActiveHashKeyVersion = "2026-04",
+                EncryptionKeysConfiguration = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["2026-04"] = keyMaterial
+                },
+                HashKeysConfiguration = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["2026-04"] = keyMaterial
+                }
+            };
+            return new AesPnrProtectionService(Options.Create(options));
+        }
+
+        private static ApplicationDbContext CreateDb()
+        {
+            var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new ApplicationDbContext(dbOptions);
+        }
+
+        private static ParticipantPersonService CreateService(ApplicationDbContext db)
+        {
+            var pnrService = CreatePnrService();
+            var validator = new SwedishPersonalIdentityNumberValidator();
+            return new ParticipantPersonService(db, pnrService, validator);
+        }
+
+        [Fact]
+        public async Task CreateWithPnrAsync_ShouldCreatePerson_WithEncryptedPnrAndHash()
+        {
+            using var db = CreateDb();
+            var service = CreateService(db);
+
+            var person = await service.CreateWithPnrAsync(
+                "test@example.com",
+                "Test Person",
+                "199001010017");
+
+            Assert.NotNull(person);
+            Assert.NotNull(person.EncryptedPnr);
+            Assert.NotNull(person.PnrHash);
+            Assert.NotNull(person.PnrKeyVersion);
+            Assert.DoesNotContain("199001010017", person.EncryptedPnr);
+            Assert.DoesNotContain("199001010017", person.PnrHash);
+        }
+
+        [Fact]
+        public async Task CreateWithPnrAsync_ShouldThrow_WhenDuplicatePnr()
+        {
+            using var db = CreateDb();
+            var service = CreateService(db);
+
+            await service.CreateWithPnrAsync("first@example.com", "First", "199001010017");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.CreateWithPnrAsync("second@example.com", "Second", "199001010017"));
+        }
+
+        [Fact]
+        public async Task CreateWithPnrAsync_ShouldThrow_WhenInvalidPnr()
+        {
+            using var db = CreateDb();
+            var service = CreateService(db);
+
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                service.CreateWithPnrAsync("test@example.com", "Test", "not-a-pnr"));
+        }
+
+        [Fact]
+        public async Task FindByPnrAsync_ShouldReturnPerson_WhenPnrExists()
+        {
+            using var db = CreateDb();
+            var service = CreateService(db);
+
+            await service.CreateWithPnrAsync("test@example.com", "Test Person", "199001010017");
+
+            var found = await service.FindByPnrAsync("199001010017");
+
+            Assert.NotNull(found);
+            Assert.Equal("test@example.com", found.Email);
+        }
+
+        [Fact]
+        public async Task FindByPnrAsync_ShouldReturnNull_WhenPnrDoesNotExist()
+        {
+            using var db = CreateDb();
+            var service = CreateService(db);
+
+            var found = await service.FindByPnrAsync("199001010017");
+
+            Assert.Null(found);
+        }
+
+        [Fact]
+        public async Task ExistsByPnrAsync_ShouldReturnTrue_WhenPnrExists()
+        {
+            using var db = CreateDb();
+            var service = CreateService(db);
+
+            await service.CreateWithPnrAsync("test@example.com", "Test", "199001010017");
+
+            var exists = await service.ExistsByPnrAsync("199001010017");
+
+            Assert.True(exists);
+        }
+
+        [Fact]
+        public async Task ExistsByPnrAsync_ShouldReturnFalse_WhenPnrDoesNotExist()
+        {
+            using var db = CreateDb();
+            var service = CreateService(db);
+
+            var exists = await service.ExistsByPnrAsync("199001010017");
+
+            Assert.False(exists);
+        }
+
+        [Fact]
+        public async Task FindByPnrAsync_ShouldAcceptDifferentFormats_ForSamePnr()
+        {
+            using var db = CreateDb();
+            var service = CreateService(db);
+
+            // Create with 12-digit format
+            await service.CreateWithPnrAsync("test@example.com", "Test", "199001010017");
+
+            // Find with 10-digit format with separator
+            var found = await service.FindByPnrAsync("900101-0017");
+
+            Assert.NotNull(found);
+            Assert.Equal("test@example.com", found.Email);
+        }
+    }
+}


### PR DESCRIPTION
## Vad
Utökar ParticipantPersonService med FindByPnrAsync, ExistsByPnrAsync och CreateWithPnrAsync.

## Varför
Sökning och dedupe ska ske via hash, aldrig via klartext-PNR.

## Tester
65 tester – alla gröna.

Closes #12