### PR TITLE
feat: Nyckelhantering för PNR-kryptering och hash

### DIFF
--- a/CertifiedSkill/Services/Pnr/PnrKeyManagementService.cs
+++ b/CertifiedSkill/Services/Pnr/PnrKeyManagementService.cs
@@ -1,0 +1,75 @@
+using CertifiedSkill.Data.Protection;
+using Microsoft.Extensions.Options;
+
+namespace CertifiedSkill.Services.Pnr
+{
+    /// <summary>
+    /// Provides helper utilities for PNR key management.
+    /// Handles startup validation and development key generation.
+    /// In production, keys must be stored in Azure Key Vault.
+    /// </summary>
+    public sealed class PnrKeyManagementService
+    {
+        private readonly PnrProtectionOptions _options;
+        private readonly ILogger<PnrKeyManagementService> _logger;
+
+        public PnrKeyManagementService(
+            IOptions<PnrProtectionOptions> options,
+            ILogger<PnrKeyManagementService> logger)
+        {
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Returns true if PNR protection is enabled and configured.
+        /// </summary>
+        public bool IsEnabled => _options.Enabled;
+
+        /// <summary>
+        /// Returns the active encryption key version.
+        /// </summary>
+        public string ActiveEncryptionKeyVersion => _options.ActiveEncryptionKeyVersion;
+
+        /// <summary>
+        /// Returns the active hash key version.
+        /// </summary>
+        public string ActiveHashKeyVersion => _options.ActiveHashKeyVersion;
+
+        /// <summary>
+        /// Logs the current key configuration status without exposing key material.
+        /// Safe to call on startup for audit purposes.
+        /// </summary>
+        public void LogKeyStatus()
+        {
+            if (!_options.Enabled)
+            {
+                _logger.LogInformation(
+                    "PNR protection is disabled. No key material loaded.");
+                return;
+            }
+
+            _logger.LogInformation(
+                "PNR protection is enabled. " +
+                "Encryption keys configured: {EncryptionKeyCount}. " +
+                "Hash keys configured: {HashKeyCount}. " +
+                "Active encryption version: {ActiveEncryptionVersion}. " +
+                "Active hash version: {ActiveHashVersion}.",
+                _options.EncryptionKeys.Count,
+                _options.HashKeys.Count,
+                _options.ActiveEncryptionKeyVersion,
+                _options.ActiveHashKeyVersion);
+        }
+
+        /// <summary>
+        /// Generates a new random base64-encoded key suitable for use as
+        /// PNR encryption or hash key material. For development use only.
+        /// Never use generated keys directly in production.
+        /// </summary>
+        public static string GenerateDevKey()
+        {
+            var keyBytes = System.Security.Cryptography.RandomNumberGenerator.GetBytes(32);
+            return Convert.ToBase64String(keyBytes);
+        }
+    }
+}

--- a/CertifiedSkill/Tests/CertifiedSkill.Tests/PnrKeyManagementServiceTests.cs
+++ b/CertifiedSkill/Tests/CertifiedSkill.Tests/PnrKeyManagementServiceTests.cs
@@ -1,0 +1,76 @@
+using CertifiedSkill.Data.Protection;
+using CertifiedSkill.Services.Pnr;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace CertifiedSkill.Tests
+{
+    public class PnrKeyManagementServiceTests
+    {
+        private static PnrKeyManagementService CreateService(bool enabled = true)
+        {
+            var keyMaterial = Convert.ToBase64String(new byte[32]);
+            var options = new PnrProtectionOptions
+            {
+                Enabled = enabled,
+                ActiveEncryptionKeyVersion = "2026-04",
+                ActiveHashKeyVersion = "2026-04",
+                EncryptionKeysConfiguration = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["2026-04"] = keyMaterial
+                },
+                HashKeysConfiguration = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["2026-04"] = keyMaterial
+                }
+            };
+            return new PnrKeyManagementService(
+                Options.Create(options),
+                NullLogger<PnrKeyManagementService>.Instance);
+        }
+
+        [Fact]
+        public void IsEnabled_ShouldReturnTrue_WhenProtectionEnabled()
+        {
+            var service = CreateService(enabled: true);
+            Assert.True(service.IsEnabled);
+        }
+
+        [Fact]
+        public void IsEnabled_ShouldReturnFalse_WhenProtectionDisabled()
+        {
+            var service = CreateService(enabled: false);
+            Assert.False(service.IsEnabled);
+        }
+
+        [Fact]
+        public void ActiveEncryptionKeyVersion_ShouldReturnConfiguredVersion()
+        {
+            var service = CreateService();
+            Assert.Equal("2026-04", service.ActiveEncryptionKeyVersion);
+        }
+
+        [Fact]
+        public void ActiveHashKeyVersion_ShouldReturnConfiguredVersion()
+        {
+            var service = CreateService();
+            Assert.Equal("2026-04", service.ActiveHashKeyVersion);
+        }
+
+        [Fact]
+        public void GenerateDevKey_ShouldReturn32ByteBase64Key()
+        {
+            var key = PnrKeyManagementService.GenerateDevKey();
+            var keyBytes = Convert.FromBase64String(key);
+            Assert.Equal(32, keyBytes.Length);
+        }
+
+        [Fact]
+        public void GenerateDevKey_ShouldReturnUniqueKeys()
+        {
+            var key1 = PnrKeyManagementService.GenerateDevKey();
+            var key2 = PnrKeyManagementService.GenerateDevKey();
+            Assert.NotEqual(key1, key2);
+        }
+    }
+}


### PR DESCRIPTION
## Vad
Lägger till PnrKeyManagementService för nyckelstatus, loggning och generering av dev-nycklar.

## Varför
Systemet behöver en kontrollerad hantering av krypteringsnycklar med tydlig separation mellan dev och produktion. Loggar aldrig nyckelmaterial.

## Tester
71 tester – alla gröna.

Closes #60