### PR TITLE
feat: API för att länka extern identitet till person

### DIFF
--- a/CertifiedSkill/CertifiedSkill.csproj
+++ b/CertifiedSkill/CertifiedSkill.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.4" />
   </ItemGroup>

--- a/CertifiedSkill/Data/ApplicationDbContext.cs
+++ b/CertifiedSkill/Data/ApplicationDbContext.cs
@@ -10,6 +10,7 @@ namespace CertifiedSkill.Data
         public DbSet<Certificate> Certificates => Set<Certificate>();
         public DbSet<ParticipantMagicLinkToken> ParticipantMagicLinkTokens => Set<ParticipantMagicLinkToken>();
         public DbSet<Consent> Consents => Set<Consent>();
+        public DbSet<ExternalIdentity> ExternalIdentities => Set<ExternalIdentity>();
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -61,6 +62,19 @@ namespace CertifiedSkill.Data
                 entity.Property(e => e.GrantedAt).IsRequired();
                 entity.HasOne(e => e.Person)
                     .WithMany(p => p.Consents)
+                    .HasForeignKey(e => e.PersonId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            builder.Entity<ExternalIdentity>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Provider).HasMaxLength(64).IsRequired();
+                entity.Property(e => e.ProviderSubjectId).HasMaxLength(256).IsRequired();
+                entity.Property(e => e.LinkedAt).IsRequired();
+                entity.HasIndex(e => new { e.Provider, e.ProviderSubjectId }).IsUnique();
+                entity.HasOne(e => e.Person)
+                    .WithMany(p => p.ExternalIdentities)
                     .HasForeignKey(e => e.PersonId)
                     .OnDelete(DeleteBehavior.Cascade);
             });

--- a/CertifiedSkill/Data/Migrations/20260610080358_AddExternalIdentity.Designer.cs
+++ b/CertifiedSkill/Data/Migrations/20260610080358_AddExternalIdentity.Designer.cs
@@ -4,16 +4,19 @@ using CertifiedSkill.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace CertifiedSkill.Migrations
+namespace CertifiedSkill.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610080358_AddExternalIdentity")]
+    partial class AddExternalIdentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CertifiedSkill/Data/Migrations/20260610080358_AddExternalIdentity.cs
+++ b/CertifiedSkill/Data/Migrations/20260610080358_AddExternalIdentity.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CertifiedSkill.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalIdentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExternalIdentities",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PersonId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Provider = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    ProviderSubjectId = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    LinkedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExternalIdentities", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExternalIdentities_Persons_PersonId",
+                        column: x => x.PersonId,
+                        principalTable: "Persons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalIdentities_PersonId",
+                table: "ExternalIdentities",
+                column: "PersonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalIdentities_Provider_ProviderSubjectId",
+                table: "ExternalIdentities",
+                columns: new[] { "Provider", "ProviderSubjectId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExternalIdentities");
+        }
+    }
+}

--- a/CertifiedSkill/Data/Participant/ExternalIdentity.cs
+++ b/CertifiedSkill/Data/Participant/ExternalIdentity.cs
@@ -1,0 +1,30 @@
+namespace CertifiedSkill.Data.Participant
+{
+    /// <summary>
+    /// Represents an external identity linked to a Person,
+    /// such as a BankID or other verified identity provider.
+    /// </summary>
+    public class ExternalIdentity
+    {
+        public Guid Id { get; init; } = Guid.NewGuid();
+
+        public Guid PersonId { get; init; }
+
+        /// <summary>
+        /// The identity provider, e.g. "BankID".
+        /// </summary>
+        public string Provider { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The unique subject identifier from the provider.
+        /// </summary>
+        public string ProviderSubjectId { get; init; } = string.Empty;
+
+        /// <summary>
+        /// When this external identity was linked.
+        /// </summary>
+        public DateTimeOffset LinkedAt { get; init; } = DateTimeOffset.UtcNow;
+
+        public Person Person { get; init; } = null!;
+    }
+}

--- a/CertifiedSkill/Data/Participant/Person.cs
+++ b/CertifiedSkill/Data/Participant/Person.cs
@@ -35,5 +35,7 @@ namespace CertifiedSkill.Data.Participant
         public ICollection<Certificate> Certificates { get; init; } = new List<Certificate>();
 
         public ICollection<Consent> Consents { get; init; } = new List<Consent>();
+
+        public ICollection<ExternalIdentity> ExternalIdentities { get; init; } = new List<ExternalIdentity>();
     }
 }

--- a/CertifiedSkill/Services/Participant/ExternalIdentityService.cs
+++ b/CertifiedSkill/Services/Participant/ExternalIdentityService.cs
@@ -1,0 +1,80 @@
+using CertifiedSkill.Data;
+using CertifiedSkill.Data.Participant;
+using Microsoft.EntityFrameworkCore;
+
+namespace CertifiedSkill.Services.Participant
+{
+    /// <summary>
+    /// Handles linking and lookup of external identities (e.g. BankID) for a Person.
+    /// </summary>
+    public class ExternalIdentityService(ApplicationDbContext db)
+    {
+        /// <summary>
+        /// Links an external identity to a person.
+        /// Throws if the person does not exist or the identity is already linked.
+        /// </summary>
+        public async Task<ExternalIdentity> LinkAsync(
+            Guid personId,
+            string provider,
+            string providerSubjectId,
+            CancellationToken cancellationToken = default)
+        {
+            var personExists = await db.Persons
+                .AnyAsync(p => p.Id == personId, cancellationToken);
+
+            if (!personExists)
+                throw new InvalidOperationException("Person not found.");
+
+            var alreadyLinked = await db.ExternalIdentities
+                .AnyAsync(e => e.Provider == provider &&
+                               e.ProviderSubjectId == providerSubjectId,
+                          cancellationToken);
+
+            if (alreadyLinked)
+                throw new InvalidOperationException(
+                    "This external identity is already linked to a person.");
+
+            var identity = new ExternalIdentity
+            {
+                PersonId = personId,
+                Provider = provider,
+                ProviderSubjectId = providerSubjectId
+            };
+
+            db.ExternalIdentities.Add(identity);
+            await db.SaveChangesAsync(cancellationToken);
+
+            return identity;
+        }
+
+        /// <summary>
+        /// Finds a person by external identity provider and subject ID.
+        /// Returns null if not found.
+        /// </summary>
+        public async Task<Person?> FindPersonByExternalIdentityAsync(
+            string provider,
+            string providerSubjectId,
+            CancellationToken cancellationToken = default)
+        {
+            var identity = await db.ExternalIdentities
+                .Include(e => e.Person)
+                .FirstOrDefaultAsync(e => e.Provider == provider &&
+                                          e.ProviderSubjectId == providerSubjectId,
+                                    cancellationToken);
+
+            return identity?.Person;
+        }
+
+        /// <summary>
+        /// Returns all external identities linked to a person.
+        /// </summary>
+        public async Task<IReadOnlyList<ExternalIdentity>> GetByPersonAsync(
+            Guid personId,
+            CancellationToken cancellationToken = default)
+        {
+            return await db.ExternalIdentities
+                .Where(e => e.PersonId == personId)
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/CertifiedSkill/Tests/CertifiedSkill.Tests/ExternalIdentityServiceTests.cs
+++ b/CertifiedSkill/Tests/CertifiedSkill.Tests/ExternalIdentityServiceTests.cs
@@ -1,0 +1,111 @@
+using CertifiedSkill.Data;
+using CertifiedSkill.Data.Participant;
+using CertifiedSkill.Services.Participant;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace CertifiedSkill.Tests
+{
+    public class ExternalIdentityServiceTests
+    {
+        private static ApplicationDbContext CreateDb()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlite(connection)
+                .Options;
+            var db = new ApplicationDbContext(options);
+            db.Database.EnsureCreated();
+            return db;
+        }
+
+        private static async Task<Person> CreatePersonAsync(ApplicationDbContext db)
+        {
+            var person = new Person
+            {
+                Email = "test@example.com",
+                DisplayName = "Test Person"
+            };
+            db.Persons.Add(person);
+            await db.SaveChangesAsync();
+            return person;
+        }
+
+        [Fact]
+        public async Task LinkAsync_ShouldLinkExternalIdentity_WhenPersonExists()
+        {
+            using var db = CreateDb();
+            var person = await CreatePersonAsync(db);
+            var service = new ExternalIdentityService(db);
+
+            var identity = await service.LinkAsync(person.Id, "BankID", "199001010017");
+
+            Assert.Equal("BankID", identity.Provider);
+            Assert.Equal("199001010017", identity.ProviderSubjectId);
+            Assert.Equal(person.Id, identity.PersonId);
+        }
+
+        [Fact]
+        public async Task LinkAsync_ShouldThrow_WhenPersonDoesNotExist()
+        {
+            using var db = CreateDb();
+            var service = new ExternalIdentityService(db);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.LinkAsync(Guid.NewGuid(), "BankID", "199001010017"));
+        }
+
+        [Fact]
+        public async Task LinkAsync_ShouldThrow_WhenIdentityAlreadyLinked()
+        {
+            using var db = CreateDb();
+            var person = await CreatePersonAsync(db);
+            var service = new ExternalIdentityService(db);
+
+            await service.LinkAsync(person.Id, "BankID", "199001010017");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.LinkAsync(person.Id, "BankID", "199001010017"));
+        }
+
+        [Fact]
+        public async Task FindPersonByExternalIdentityAsync_ShouldReturnPerson_WhenLinked()
+        {
+            using var db = CreateDb();
+            var person = await CreatePersonAsync(db);
+            var service = new ExternalIdentityService(db);
+
+            await service.LinkAsync(person.Id, "BankID", "199001010017");
+            var found = await service.FindPersonByExternalIdentityAsync("BankID", "199001010017");
+
+            Assert.NotNull(found);
+            Assert.Equal(person.Id, found.Id);
+        }
+
+        [Fact]
+        public async Task FindPersonByExternalIdentityAsync_ShouldReturnNull_WhenNotLinked()
+        {
+            using var db = CreateDb();
+            var service = new ExternalIdentityService(db);
+
+            var found = await service.FindPersonByExternalIdentityAsync("BankID", "199001010017");
+
+            Assert.Null(found);
+        }
+
+        [Fact]
+        public async Task GetByPersonAsync_ShouldReturnLinkedIdentities()
+        {
+            using var db = CreateDb();
+            var person = await CreatePersonAsync(db);
+            var service = new ExternalIdentityService(db);
+
+            await service.LinkAsync(person.Id, "BankID", "199001010017");
+            var identities = await service.GetByPersonAsync(person.Id);
+
+            Assert.Single(identities);
+            Assert.Equal("BankID", identities[0].Provider);
+        }
+    }
+}

--- a/CertifiedSkill/Tests/CertifiedSkill.Tests/ExternalIdentityTests.cs
+++ b/CertifiedSkill/Tests/CertifiedSkill.Tests/ExternalIdentityTests.cs
@@ -1,0 +1,60 @@
+using CertifiedSkill.Data.Participant;
+
+namespace CertifiedSkill.Tests
+{
+    public class ExternalIdentityTests
+    {
+        [Fact]
+        public void ExternalIdentity_ShouldHaveProvider_WhenCreated()
+        {
+            var identity = new ExternalIdentity
+            {
+                PersonId = Guid.NewGuid(),
+                Provider = "BankID",
+                ProviderSubjectId = "198507102391"
+            };
+
+            Assert.Equal("BankID", identity.Provider);
+        }
+
+        [Fact]
+        public void ExternalIdentity_ShouldHaveProviderSubjectId_WhenCreated()
+        {
+            var identity = new ExternalIdentity
+            {
+                PersonId = Guid.NewGuid(),
+                Provider = "BankID",
+                ProviderSubjectId = "198507102391"
+            };
+
+            Assert.Equal("198507102391", identity.ProviderSubjectId);
+        }
+
+        [Fact]
+        public void ExternalIdentity_ShouldSetLinkedAt_WhenCreated()
+        {
+            var before = DateTimeOffset.UtcNow;
+
+            var identity = new ExternalIdentity
+            {
+                PersonId = Guid.NewGuid(),
+                Provider = "BankID",
+                ProviderSubjectId = "198507102391"
+            };
+
+            Assert.True(identity.LinkedAt >= before);
+        }
+
+        [Fact]
+        public void Person_ShouldHaveEmptyExternalIdentities_WhenCreated()
+        {
+            var person = new Person
+            {
+                Email = "test@example.com",
+                DisplayName = "Test Person"
+            };
+
+            Assert.Empty(person.ExternalIdentities);
+        }
+    }
+}


### PR DESCRIPTION
## Vad
Lägger till ExternalIdentityService för att länka, söka och hämta externa identiteter kopplade till en Person.

## Varför
Förbereder systemet för framtida BankID-integration med ett tydligt API.

## Tester
85 tester – alla gröna.

Closes #19