### PR TITLE
feat: BankID integrationsgränssnitt och sandbox-strategi

### DIFF
--- a/CertifiedSkill/Services/Participant/IBankIdIdentityProvider.cs
+++ b/CertifiedSkill/Services/Participant/IBankIdIdentityProvider.cs
@@ -1,0 +1,42 @@
+namespace CertifiedSkill.Services.Participant
+{
+    /// <summary>
+    /// Defines the contract for a BankID identity provider.
+    /// Implementations can be swapped between sandbox and production
+    /// without changing the consuming code.
+    /// </summary>
+    public interface IBankIdIdentityProvider
+    {
+        /// <summary>
+        /// Initiates a BankID authentication session.
+        /// Returns a session token to be used for polling.
+        /// </summary>
+        Task<string> InitiateAuthAsync(string personalNumber, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Polls the status of an ongoing BankID authentication session.
+        /// </summary>
+        Task<BankIdAuthResult> PollAuthAsync(string sessionToken, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Represents the result of a BankID authentication poll.
+    /// </summary>
+    public sealed class BankIdAuthResult
+    {
+        public BankIdAuthStatus Status { get; init; }
+
+        /// <summary>
+        /// The verified subject identifier from BankID.
+        /// Only set when Status is Complete.
+        /// </summary>
+        public string? SubjectId { get; init; }
+    }
+
+    public enum BankIdAuthStatus
+    {
+        Pending,
+        Complete,
+        Failed
+    }
+}

--- a/CertifiedSkill/Services/Participant/SandboxBankIdIdentityProvider.cs
+++ b/CertifiedSkill/Services/Participant/SandboxBankIdIdentityProvider.cs
@@ -1,0 +1,40 @@
+namespace CertifiedSkill.Services.Participant
+{
+    /// <summary>
+    /// Sandbox implementation of IBankIdIdentityProvider for development and testing.
+    /// Always returns a successful authentication without contacting real BankID.
+    /// Never use in production.
+    /// </summary>
+    public sealed class SandboxBankIdIdentityProvider : IBankIdIdentityProvider
+    {
+        private readonly Dictionary<string, string> _sessions = new();
+
+        public Task<string> InitiateAuthAsync(
+            string personalNumber,
+            CancellationToken cancellationToken = default)
+        {
+            var sessionToken = Guid.NewGuid().ToString();
+            _sessions[sessionToken] = personalNumber;
+            return Task.FromResult(sessionToken);
+        }
+
+        public Task<BankIdAuthResult> PollAuthAsync(
+            string sessionToken,
+            CancellationToken cancellationToken = default)
+        {
+            if (_sessions.TryGetValue(sessionToken, out var personalNumber))
+            {
+                return Task.FromResult(new BankIdAuthResult
+                {
+                    Status = BankIdAuthStatus.Complete,
+                    SubjectId = personalNumber
+                });
+            }
+
+            return Task.FromResult(new BankIdAuthResult
+            {
+                Status = BankIdAuthStatus.Failed
+            });
+        }
+    }
+}

--- a/CertifiedSkill/Tests/CertifiedSkill.Tests/BankIdSandboxTests.cs
+++ b/CertifiedSkill/Tests/CertifiedSkill.Tests/BankIdSandboxTests.cs
@@ -1,0 +1,51 @@
+using CertifiedSkill.Services.Participant;
+
+namespace CertifiedSkill.Tests
+{
+    public class BankIdSandboxTests
+    {
+        [Fact]
+        public async Task InitiateAuthAsync_ShouldReturnSessionToken()
+        {
+            var provider = new SandboxBankIdIdentityProvider();
+
+            var token = await provider.InitiateAuthAsync("199001010017");
+
+            Assert.NotEmpty(token);
+        }
+
+        [Fact]
+        public async Task PollAuthAsync_ShouldReturnComplete_WhenSessionExists()
+        {
+            var provider = new SandboxBankIdIdentityProvider();
+
+            var token = await provider.InitiateAuthAsync("199001010017");
+            var result = await provider.PollAuthAsync(token);
+
+            Assert.Equal(BankIdAuthStatus.Complete, result.Status);
+            Assert.Equal("199001010017", result.SubjectId);
+        }
+
+        [Fact]
+        public async Task PollAuthAsync_ShouldReturnFailed_WhenSessionDoesNotExist()
+        {
+            var provider = new SandboxBankIdIdentityProvider();
+
+            var result = await provider.PollAuthAsync("invalid-token");
+
+            Assert.Equal(BankIdAuthStatus.Failed, result.Status);
+            Assert.Null(result.SubjectId);
+        }
+
+        [Fact]
+        public async Task InitiateAuthAsync_ShouldReturnUniqueTokens()
+        {
+            var provider = new SandboxBankIdIdentityProvider();
+
+            var token1 = await provider.InitiateAuthAsync("199001010017");
+            var token2 = await provider.InitiateAuthAsync("199001010017");
+
+            Assert.NotEqual(token1, token2);
+        }
+    }
+}


### PR DESCRIPTION
## Vad
Lägger till IBankIdIdentityProvider-interface och en sandbox-implementation för utveckling och testning.

## Varför
Definierar kontraktet för framtida BankID-integration. Sandbox-implementationen gör det möjligt att testa flödet utan att ansluta till riktigt BankID.

## Tester
79 tester – alla gröna.

Closes #61