### PR TITLE
feat: CSV-export per kursomgång med PNR-skydd

### DIFF
--- a/CertifiedSkill/CertifiedSkill.csproj
+++ b/CertifiedSkill/CertifiedSkill.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.4" />
   </ItemGroup>

--- a/CertifiedSkill/Services/Export/CourseExportService.cs
+++ b/CertifiedSkill/Services/Export/CourseExportService.cs
@@ -1,0 +1,75 @@
+using CertifiedSkill.Data;
+using CertifiedSkill.Data.Participant;
+using Microsoft.EntityFrameworkCore;
+using System.Text;
+
+namespace CertifiedSkill.Services.Export
+{
+    /// <summary>
+    /// Exports course round results as CSV.
+    /// PNR is never included in any export - by design.
+    /// </summary>
+    public class CourseExportService(ApplicationDbContext db)
+    {
+        /// <summary>
+        /// Exports all certificates for a given course name as CSV.
+        /// The export contains: DisplayName, Email, CourseName, CourseVersion, IssuedAt, Status.
+        /// PNR is explicitly excluded.
+        /// </summary>
+        public async Task<string> ExportCertificatesCsvAsync(
+            string courseName,
+            CancellationToken cancellationToken = default)
+        {
+            var certificates = await db.Certificates
+                .Include(c => c.Person)
+                .Where(c => c.CourseName == courseName)
+                .OrderBy(c => c.Person.DisplayName)
+                .ToListAsync(cancellationToken);
+
+            return BuildCsv(certificates);
+        }
+
+        /// <summary>
+        /// Exports all certificates as CSV.
+        /// PNR is explicitly excluded.
+        /// </summary>
+        public async Task<string> ExportAllCertificatesCsvAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var certificates = await db.Certificates
+                .Include(c => c.Person)
+                .OrderBy(c => c.CourseName)
+                .ThenBy(c => c.Person.DisplayName)
+                .ToListAsync(cancellationToken);
+
+            return BuildCsv(certificates);
+        }
+
+        private static string BuildCsv(IEnumerable<Certificate> certificates)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("DisplayName,Email,CourseName,CourseVersion,IssuedAt,Status");
+
+            foreach (var cert in certificates)
+            {
+                var displayName = EscapeCsv(cert.Person.DisplayName);
+                var email = EscapeCsv(cert.Person.Email);
+                var courseName = EscapeCsv(cert.CourseName);
+                var courseVersion = EscapeCsv(cert.CourseVersion);
+                var issuedAt = cert.IssuedAt.ToString("yyyy-MM-dd");
+                var status = cert.Status.ToString();
+
+                sb.AppendLine($"{displayName},{email},{courseName},{courseVersion},{issuedAt},{status}");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string EscapeCsv(string value)
+        {
+            if (value.Contains(',') || value.Contains('"') || value.Contains('\n'))
+                return $"\"{value.Replace("\"", "\"\"")}\"";
+            return value;
+        }
+    }
+}

--- a/CertifiedSkill/Tests/CertifiedSkill.Tests/CourseExportServiceTests.cs
+++ b/CertifiedSkill/Tests/CertifiedSkill.Tests/CourseExportServiceTests.cs
@@ -1,0 +1,106 @@
+using CertifiedSkill.Data;
+using CertifiedSkill.Data.Participant;
+using CertifiedSkill.Services.Export;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace CertifiedSkill.Tests
+{
+    public class CourseExportServiceTests
+    {
+        private static ApplicationDbContext CreateDb()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlite(connection)
+                .Options;
+            var db = new ApplicationDbContext(options);
+            db.Database.EnsureCreated();
+            return db;
+        }
+
+        private static async Task<Person> CreatePersonAsync(ApplicationDbContext db, string email, string name)
+        {
+            var person = new Person { Email = email, DisplayName = name };
+            db.Persons.Add(person);
+            await db.SaveChangesAsync();
+            return person;
+        }
+
+        private static async Task<Certificate> CreateCertificateAsync(
+            ApplicationDbContext db, Person person, string courseName, string version)
+        {
+            var cert = new Certificate
+            {
+                PersonId = person.Id,
+                CourseName = courseName,
+                CourseVersion = version,
+                IssuedAt = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero),
+                Status = CertificateStatus.Active
+            };
+            db.Certificates.Add(cert);
+            await db.SaveChangesAsync();
+            return cert;
+        }
+
+        [Fact]
+        public async Task ExportCertificatesCsvAsync_ShouldContainHeader()
+        {
+            using var db = CreateDb();
+            var service = new CourseExportService(db);
+
+            var csv = await service.ExportCertificatesCsvAsync("Test Course");
+
+            Assert.Contains("DisplayName,Email,CourseName,CourseVersion,IssuedAt,Status", csv);
+        }
+
+        [Fact]
+        public async Task ExportCertificatesCsvAsync_ShouldNotContainPnr()
+        {
+            using var db = CreateDb();
+            var person = await CreatePersonAsync(db, "test@example.com", "Test Person");
+            person.EncryptedPnr = "encrypted-pnr-value";
+            person.PnrHash = "hash-value";
+            await db.SaveChangesAsync();
+            await CreateCertificateAsync(db, person, "Test Course", "1.0");
+            var service = new CourseExportService(db);
+
+            var csv = await service.ExportCertificatesCsvAsync("Test Course");
+
+            Assert.DoesNotContain("encrypted-pnr-value", csv);
+            Assert.DoesNotContain("hash-value", csv);
+        }
+
+        [Fact]
+        public async Task ExportCertificatesCsvAsync_ShouldContainPersonData()
+        {
+            using var db = CreateDb();
+            var person = await CreatePersonAsync(db, "test@example.com", "Test Person");
+            await CreateCertificateAsync(db, person, "Test Course", "1.0");
+            var service = new CourseExportService(db);
+
+            var csv = await service.ExportCertificatesCsvAsync("Test Course");
+
+            Assert.Contains("Test Person", csv);
+            Assert.Contains("test@example.com", csv);
+            Assert.Contains("Test Course", csv);
+        }
+
+        [Fact]
+        public async Task ExportAllCertificatesCsvAsync_ShouldReturnAllCertificates()
+        {
+            using var db = CreateDb();
+            var person1 = await CreatePersonAsync(db, "a@example.com", "Person A");
+            var person2 = await CreatePersonAsync(db, "b@example.com", "Person B");
+            await CreateCertificateAsync(db, person1, "Course A", "1.0");
+            await CreateCertificateAsync(db, person2, "Course B", "2.0");
+            var service = new CourseExportService(db);
+
+            var csv = await service.ExportAllCertificatesCsvAsync();
+
+            Assert.Contains("Person A", csv);
+            Assert.Contains("Person B", csv);
+        }
+    }
+}


### PR DESCRIPTION
## Vad
Lägger till CourseExportService för CSV-export av certifikat per kurs. PNR är explicit uteslutet från all export.

## Varför
GDPR kräver att personnummer aldrig exporteras. Exportfunktionen är designad för att omöjliggöra detta.

## Tester
79 tester – alla gröna.

Closes #44
Closes #43